### PR TITLE
Removed start time offset from all the events

### DIFF
--- a/gp_parser.cpp
+++ b/gp_parser.cpp
@@ -177,7 +177,7 @@ Parser::Parser(const char *filePath)
 	// Iterate through measures
 	auto tempo = Tempo();
 	tempo.value = tempoValue;
-	auto start = QUARTER_TIME;
+	auto start = 0;
 	for (auto i = 0; i < measures; ++i) {
 		auto& header = measureHeaders[i];
 		header.start = start;


### PR DESCRIPTION
What was the intention of adding a quarter time offset to everything?
Maybe it's a bug caused by some refactoring of the further code?